### PR TITLE
Handle omitted Properties

### DIFF
--- a/order.go
+++ b/order.go
@@ -212,7 +212,7 @@ func (li *LineItem) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		li.Properties = p
-	} else { // else we unmarshal it into a struct
+	} else if (aux.Properties != nil) { // else we unmarshal it into a struct if set
 		var p NoteAttribute
 		err = json.Unmarshal(aux.Properties, &p)
 		if err != nil {


### PR DESCRIPTION
Fixes an issue where if Properties was omitted the JSON unmarshaller would error with `unexpected end of JSON input`